### PR TITLE
Support 2x5 signals

### DIFF
--- a/rpv_matcher/rpv_matcher.py
+++ b/rpv_matcher/rpv_matcher.py
@@ -87,6 +87,7 @@ class RPVParton(ROOT.TLorentzVector):
             self.SetPtEtaPhiE(args[0], args[1], args[2], args[3])
         self.__quark_barcode = -999  # barcode of last quark in chain corresponding to this FSR # noqa
         self.__gluino_barcode = -999  # barcode of corresponding gluino
+        self.__neutralino_barcode = -999  # barcode of corresponding neutralino (optional)
         self.__barcode = -999  # particle's barcode
         self.__pdgID = -999  # particle's pdg ID
 
@@ -99,8 +100,14 @@ class RPVParton(ROOT.TLorentzVector):
     def set_gluino_barcode(self, barcode):
         self.__gluino_barcode = barcode
 
+    def set_neutralino_barcode(self, barcode):
+        self.__neutralino_barcode = barcode
+
     def get_gluino_barcode(self):
         return self.__gluino_barcode
+
+    def get_neutralino_barcode(self):
+        return self.__neutralino_barcode
 
     def set_barcode(self, barcode):
         self.__barcode = barcode
@@ -271,7 +278,7 @@ class RPVMatcher():
                         'jet_index': info_dict['jet_index'],
                         'quark_barcode': info_dict['matched_parton_barcode'],
                         }
-                    self.__log.debug(f'Jet {info_dict["jet_index"]} is matched to FSR {info_dict["matched_parton_index"]} with last quark barcode {info_dict["matched_parton_barcode"]} [check passed!]') # noqa
+                    self.__log.debug(f'Jet {info_dict["jet_index"]} (eta={round(jet.Eta(), 2)}, phi={round(jet.Phi(), 2)}) is matched to FSR {info_dict["matched_parton_index"]} with last quark barcode {info_dict["matched_parton_barcode"]} [check passed!]') # noqa
                     if 'pdgid' in info_dict:
                         # Jets are matched to partons using FT decisions
                         self.__decorate_jet(
@@ -295,7 +302,7 @@ class RPVMatcher():
                 'jet_index': info_dict['jet_index'],
                 'quark_barcode': info_dict['matched_parton_barcode']
                 }
-            self.__log.debug(f'Jet {info_dict["jet_index"]} is matched to FSR {info_dict["matched_parton_index"]} with last quark barcode {info_dict["matched_parton_barcode"]} [check passed!]') # noqa
+            self.__log.debug(f'Jet {info_dict["jet_index"]} (eta={round(jet.Eta(), 2)}, phi={round(jet.Phi(), 2)}) is matched to FSR {info_dict["matched_parton_index"]} with last quark barcode {info_dict["matched_parton_barcode"]} [check passed!]') # noqa
             if 'pdgid' in info_dict:
                 # Jets are matched to partons using FT decisions
                 self.__decorate_jet(
@@ -341,7 +348,7 @@ class RPVMatcher():
                     matched_parton_barcode = barcode
             if dr_min < dr_cut:  # jet is matched
                 if is_fsr:
-                    self.__log.debug(f'Jet {jet_index} is matched (DeltaR={dr_min}) to FSR {matched_parton_index} with last quark barcode {matched_parton_barcode} [check pending...]') # noqa
+                    self.__log.debug(f'Jet {jet_index} (eta={round(jet.Eta(), 2)}, phi={round(jet.Phi(), 2)}) is matched (DeltaR={round(dr_min, 2)}) to FSR {matched_parton_index} with last quark barcode {matched_parton_barcode} [check pending...]') # noqa
                     info_dict = {
                         'jet_index': jet_index,
                         'matched_parton_index': matched_parton_index,
@@ -353,7 +360,7 @@ class RPVMatcher():
                         info_dict=info_dict
                         )
                 else:  # not an FSR
-                    self.__log.debug(f'Jet {jet_index} is matched (DeltaR={dr_min}) to last quark {matched_parton_index} with barcode {matched_parton_barcode}') # noqa
+                    self.__log.debug(f'Jet {jet_index} (eta={round(jet.Eta(), 2)}, phi={round(jet.Phi(), 2)}) is matched (DeltaR={round(dr_min, 2)}) to last quark {matched_parton_index} with barcode {matched_parton_barcode}') # noqa
                     info_dict = {
                         'matched_parton_index': matched_parton_index,
                         'matched_parton_barcode': matched_parton_barcode

--- a/rpv_matcher/rpv_matcher.py
+++ b/rpv_matcher/rpv_matcher.py
@@ -80,7 +80,6 @@ class RPVJet(ROOT.TLorentzVector):
     def get_matched_fsr_barcode(self):
         return self.__matched_fsr_barcode
 
-
 class RPVParton(ROOT.TLorentzVector):
     def __init__(self, *args):
         ROOT.TLorentzVector.__init__(self)
@@ -123,7 +122,8 @@ class RPVMatcher():
         'ReturnOnlyMatched': False,
         'Debug': False,
         'DisableNmatchedJetProtection': False,
-        'MatchFSRsFromMatchedGluinoDecays': False
+        'MatchFSRsFromMatchedGluinoDecays': False,
+        'nMatchedJets':6
         }
 
     def add_jets(self, jets: [RPVJet]):
@@ -417,11 +417,11 @@ class RPVMatcher():
         return sum([1 if jet.is_matched() else 0 for jet in self.__jets])
 
     def __check_n_matched_jets(self):
-        """ Exit if more than 6 jets were matched
+        """ Exit if more than nMatchedJets jets were matched
         (this is a protection, it should never happen) """
         n_matched_jets = self.__get_n_matched_jets()
-        if n_matched_jets > 6:
-            msg = f'more than 6 ({n_matched_jets}) jets are matched, exiting'
+        if n_matched_jets > self.__properties_defaults['nMatchedJets']:
+            msg = f'more than {self.__properties_defaults["nMatchedJets"]} ({n_matched_jets}) jets are matched, exiting'
             self.__log.fatal(msg)
             sys.exit(1)
 
@@ -447,7 +447,7 @@ class RPVMatcher():
         self.__log.debug(msg)
         self.__log.debug('Matching partons to jets')
         self.__matcher_use_deltar_values_from_ft(self.__partons, False)
-        if self.__fsrs and self.__get_n_matched_jets() < 6:
+        if self.__fsrs and self.__get_n_matched_jets() < self.__properties_defaults['nMatchedJets']:
             self.__log.debug('Matching FSRs to jets')
             self.__matcher_use_deltar_values_from_ft(self.__fsrs, True)
         if not self.__properties['DisableNmatchedJetProtection']:
@@ -465,7 +465,7 @@ class RPVMatcher():
         msg = f'Will return {case} jets'
         self.__log.debug(msg)
         self.__matcher_recompute_deltar_values(self.__partons, 0, cut)
-        if self.__fsrs and self.__get_n_matched_jets() < 6:
+        if self.__fsrs and self.__get_n_matched_jets() < self.__properties_defaults['nMatchedJets']:
             self.__matcher_recompute_deltar_values(self.__fsrs, 1, cut)
         if not properties['DisableNmatchedJetProtection']:
             self.__check_n_matched_jets()

--- a/rpv_matcher/rpv_matcher.py
+++ b/rpv_matcher/rpv_matcher.py
@@ -420,8 +420,8 @@ class RPVMatcher():
         """ Exit if more than nMatchedJets jets were matched
         (this is a protection, it should never happen) """
         n_matched_jets = self.__get_n_matched_jets()
-        if n_matched_jets > self.__properties_defaults['nMatchedJets']:
-            msg = f'more than {self.__properties_defaults["nMatchedJets"]} ({n_matched_jets}) jets are matched, exiting'
+        if n_matched_jets > self.__properties['nMatchedJets']:
+            msg = f'more than {self.__properties["nMatchedJets"]} ({n_matched_jets}) jets are matched, exiting'
             self.__log.fatal(msg)
             sys.exit(1)
 

--- a/rpv_matcher/rpv_matcher.py
+++ b/rpv_matcher/rpv_matcher.py
@@ -123,7 +123,7 @@ class RPVMatcher():
         'Debug': False,
         'DisableNmatchedJetProtection': False,
         'MatchFSRsFromMatchedGluinoDecays': False,
-        'nMatchedJets': 6
+        'maxNmatchedJets': 6
         }
 
     def add_jets(self, jets: [RPVJet]):
@@ -417,11 +417,11 @@ class RPVMatcher():
         return sum([1 if jet.is_matched() else 0 for jet in self.__jets])
 
     def __check_n_matched_jets(self):
-        """ Exit if more than nMatchedJets jets were matched
+        """ Exit if more than maxNmatchedJets jets were matched
         (this is a protection, it should never happen) """
         n_matched_jets = self.__get_n_matched_jets()
-        if n_matched_jets > self.__properties['nMatchedJets']:
-            msg = f'more than {self.__properties["nMatchedJets"]} ({n_matched_jets}) jets are matched, exiting'
+        if n_matched_jets > self.__properties['maxNmatchedJets']:
+            msg = f'more than {self.__properties["maxNmatchedJets"]} ({n_matched_jets}) jets are matched, exiting'
             self.__log.fatal(msg)
             sys.exit(1)
 
@@ -447,7 +447,7 @@ class RPVMatcher():
         self.__log.debug(msg)
         self.__log.debug('Matching partons to jets')
         self.__matcher_use_deltar_values_from_ft(self.__partons, False)
-        if self.__fsrs and self.__get_n_matched_jets() < self.__properties_defaults['nMatchedJets']:
+        if self.__fsrs and self.__get_n_matched_jets() < self.__properties['maxNmatchedJets']:
             self.__log.debug('Matching FSRs to jets')
             self.__matcher_use_deltar_values_from_ft(self.__fsrs, True)
         if not self.__properties['DisableNmatchedJetProtection']:
@@ -465,7 +465,7 @@ class RPVMatcher():
         msg = f'Will return {case} jets'
         self.__log.debug(msg)
         self.__matcher_recompute_deltar_values(self.__partons, 0, cut)
-        if self.__fsrs and self.__get_n_matched_jets() < self.__properties_defaults['nMatchedJets']:
+        if self.__fsrs and self.__get_n_matched_jets() < self.__properties['maxNmatchedJets']:
             self.__matcher_recompute_deltar_values(self.__fsrs, 1, cut)
         if not properties['DisableNmatchedJetProtection']:
             self.__check_n_matched_jets()

--- a/rpv_matcher/rpv_matcher.py
+++ b/rpv_matcher/rpv_matcher.py
@@ -123,7 +123,7 @@ class RPVMatcher():
         'Debug': False,
         'DisableNmatchedJetProtection': False,
         'MatchFSRsFromMatchedGluinoDecays': False,
-        'nMatchedJets':6
+        'nMatchedJets': 6
         }
 
     def add_jets(self, jets: [RPVJet]):


### PR DESCRIPTION
News:
- New "maxNmatchedJets" property to set the maximum number of expected matched jets. This is used:
  - to check if FSRs need to be used to try to fully match an event
  - to check if more than the expected number of jets were matched (protection)